### PR TITLE
Arrange All crashes Cura when plugin is disabled

### DIFF
--- a/CuraApplicationPatches.py
+++ b/CuraApplicationPatches.py
@@ -15,6 +15,7 @@ from cura.Scene.BlockSlicingDecorator import BlockSlicingDecorator
 
 from cura.Arranging.Arrange import Arrange
 from cura.Arranging.ShapeArray import ShapeArray
+from cura.Arranging.ArrangeObjectsJob import ArrangeObjectsJob
 
 from UM.Logger import Logger
 


### PR DESCRIPTION
Fix problem reported by @kageurufu that Cura crashes doing `arrange all models` if the plugin is disabled.